### PR TITLE
Fix PDB enum storage size handling

### DIFF
--- a/XEXLoaderWV/src/main/java/xexloaderwv/CodeViewTypeInfo.java
+++ b/XEXLoaderWV/src/main/java/xexloaderwv/CodeViewTypeInfo.java
@@ -1,0 +1,51 @@
+package xexloaderwv;
+
+final class CodeViewTypeInfo {
+
+	private CodeViewTypeInfo() {
+	}
+
+	static int getPrimitiveStorageSize(long typeIndex) {
+		switch ((int) typeIndex) {
+			case 0x0010: // T_CHAR
+			case 0x0020: // T_UCHAR
+			case 0x0068: // T_INT1
+			case 0x0069: // T_UINT1
+			case 0x0070: // T_RCHAR
+			case 0x0030: // T_BOOL08
+				return 1;
+			case 0x0011: // T_SHORT
+			case 0x0021: // T_USHORT
+			case 0x0071: // T_WCHAR
+			case 0x0072: // T_INT2
+			case 0x0073: // T_UINT2
+			case 0x0031: // T_BOOL16
+			case 0x007a: // T_CHAR16
+				return 2;
+			case 0x0008: // T_HRESULT
+			case 0x0012: // T_LONG
+			case 0x0022: // T_ULONG
+			case 0x0040: // T_REAL32
+			case 0x0074: // T_INT4
+			case 0x0075: // T_UINT4
+			case 0x0032: // T_BOOL32
+			case 0x007b: // T_CHAR32
+				return 4;
+			case 0x0013: // T_QUAD
+			case 0x0023: // T_UQUAD
+			case 0x0041: // T_REAL64
+			case 0x0076: // T_INT8
+			case 0x0077: // T_UINT8
+			case 0x0033: // T_BOOL64
+				return 8;
+			case 0x0014: // T_OCT
+			case 0x0024: // T_UOCT
+			case 0x0043: // T_REAL128
+			case 0x0078: // T_INT16
+			case 0x0079: // T_UINT16
+				return 16;
+			default:
+				return -1;
+		}
+	}
+}

--- a/XEXLoaderWV/src/main/java/xexloaderwv/TPIStream.java
+++ b/XEXLoaderWV/src/main/java/xexloaderwv/TPIStream.java
@@ -486,7 +486,7 @@ public class TPIStream {
 			if(rec.typeID == en.field)
 			{
 				TypeRecord.LR_FieldList fieldList = (TypeRecord.LR_FieldList)rec.record;
-				EnumDataType newEnum = new EnumDataType(en.name, 8);
+				EnumDataType newEnum = new EnumDataType(en.name, ResolveEnumStorageSize(en));
 				for(TypeRecord.MemberRecord m : fieldList.records)
 				{
 					TypeRecord.MR_Enumerate entry = (TypeRecord.MR_Enumerate)m;
@@ -496,6 +496,24 @@ public class TPIStream {
 				return true;
 			}
 		return false;
+	}
+
+	private int ResolveEnumStorageSize(TypeRecord.LR_Enum en)
+	{
+		int primitiveSize = CodeViewTypeInfo.getPrimitiveStorageSize(en.utype);
+		if(primitiveSize > 0)
+			return primitiveSize;
+
+		try
+		{
+			DataType dataType = GetDataTypeByIndex(en.utype);
+			if(dataType != null && dataType.getLength() > 0)
+				return dataType.getLength();
+		}
+		catch (Exception ex)
+		{
+		}
+		return 8;
 	}
 	
 	public LeafRecordKind GetTypeKind(long index)


### PR DESCRIPTION
## Summary
- stop creating every imported PDB enum as an 8-byte enum
- derive enum storage size from the CodeView underlying type when it is a known primitive
- fall back to the resolved Ghidra datatype length for non-primitive enum backing types, then preserve the old 8-byte behavior as a last resort

## Why
Issue #31 points out that PDB enums are currently hardcoded to 8 bytes. The bug is in TPIStream.AddEnumType, which always does 
ew EnumDataType(en.name, 8) even though LF_ENUM already carries the underlying type in n.utype.

## Validation
- compiled the new CodeViewTypeInfo helper and ran a smoke test against representative 1/2/4/8-byte CodeView primitive types
- compiled the patched TPIStream.java and helper directly against the local Ghidra 12.0.4 jars with javac

Closes #31.