### PR TITLE
Fix PDB sizing/root parsing, LF_ARRAY sizing, and .pdata functions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,14 +1,25 @@
 # X360 XEX Loader for Ghidra by Warranty Voider
 
-this is a loader module for ghidra for XBox360 XEX files
+This is a Ghidra loader extension for Xbox 360 XEX files.
 
-- supports PDB/XDB files
-  - In loader import page, click Advanced.
-  - Tick `Load PDB File` + `Use experimental PDB loader` and untick `Process .pdata`
-  - Select `MSDIA` parser
-- supports XEXP delta patches
+## SaveEditors Fork Updates
 
-requires min. JDK 17
+This fork carries maintained fixes and publishes ready-to-install release zips.
+
+- Fixed PDB enum imports so enums use their actual underlying storage size instead of always importing as 8-byte enums.
+- Fixed PDB root stream page counting so PDBs with sub-page root directories parse correctly.
+- Release zips for the fork are published on the [Releases](https://github.com/SaveEditors/XEXLoaderWV/releases) page.
+- The upstream patch was submitted as [zeroKilo/XEXLoaderWV#33](https://github.com/zeroKilo/XEXLoaderWV/pull/33).
+
+## Features
+
+- Supports PDB/XDB files.
+  - In the loader import page, click Advanced.
+  - Tick `Load PDB File` and `Use experimental PDB loader`, then untick `Process .pdata`.
+  - Select `MSDIA` parser.
+- Supports XEXP delta patches.
+
+Requires JDK 17 or newer.
 
 [![Alt text](https://img.youtube.com/vi/coGz0f7hHTM/0.jpg)](https://www.youtube.com/watch?v=coGz0f7hHTM)
 

--- a/README.md
+++ b/README.md
@@ -22,23 +22,38 @@ This fork carries maintained fixes and publishes ready-to-install release zips.
   - Select `MSDIA` parser.
 - Supports XEXP delta patches.
 
-Requires JDK 17 or newer.
+Requires the minimum Java version required by your Ghidra install.
 
 [![Alt text](https://img.youtube.com/vi/coGz0f7hHTM/0.jpg)](https://www.youtube.com/watch?v=coGz0f7hHTM)
 
 <!-- this video is outdated -->
 <!-- [![Alt text](https://img.youtube.com/vi/dBoofGgraKM/0.jpg)](https://www.youtube.com/watch?v=dBoofGgraKM) -->
 
-## Build problem with gradle wrapper
+## Build
 
-EDIT:2025.04.05
+This extension is built using the Gradle support files that ship with Ghidra. The required Java and Gradle versions come from:
 
-it seems you have to update
+```text
+<GHIDRA_INSTALL_DIR>\Ghidra\application.properties
+```
 
-```(Ghidra Install Dir)\Ghidra\application.properties```
+Do not edit those values in Ghidra just to build this project. Instead, use a JDK and Gradle version that satisfy your installed Ghidra release.
 
-and upgrade the gradle version like this
+For Ghidra `12.0.4`, the current minimums are:
 
-```application.gradle.min=8.10```
+```text
+application.java.min=21
+application.gradle.min=8.5
+```
 
-if you have problems with building from source in eclipse with the gradle wrapper.
+This fork was validated against Ghidra `12.0.4`, JDK `21`, and Gradle `9.3.1`.
+
+Example:
+
+```powershell
+$env:GHIDRA_INSTALL_DIR='A:\Tools\ghidra_12.0.4_PUBLIC'
+$env:JAVA_HOME='A:\Tools\jdk-21'
+gradle buildExtension
+```
+
+If you are building from Eclipse or another IDE, make sure it uses a compatible JDK and Gradle version for the Ghidra version you are targeting.

--- a/README.md
+++ b/README.md
@@ -2,6 +2,11 @@
 
 this is a loader module for ghidra for XBox360 XEX files
 
+- SaveEditors fork release: `13.0.0` (`Bug fixes`)
+- fork fixes included in this release:
+  - PDB enum sizing and root-stream parsing fixes
+  - CodeView `LF_ARRAY` byte-length handling fixes
+  - `.pdata` promotion from labels to real Ghidra functions
 - supports PDB/XDB files
   - In loader import page, click Advanced.
   - Tick `Load PDB File` + `Use experimental PDB loader` and untick `Process .pdata`

--- a/XEXLoaderWV/extension.properties
+++ b/XEXLoaderWV/extension.properties
@@ -1,5 +1,5 @@
 name=@extname@
-description=The extension description can be customized by editing the extension.properties file.
-author=
-createdOn=
-version=@extversion@
+description=Xbox 360 XEX loader for Ghidra with XEX, XEXP, PDB, and XDB support.
+author=Warranty Voider; SaveEditors fork maintenance
+createdOn=2026-03-25
+version=13.0.0

--- a/XEXLoaderWV/extension.properties
+++ b/XEXLoaderWV/extension.properties
@@ -1,5 +1,5 @@
 name=@extname@
-description=The extension description can be customized by editing the extension.properties file.
-author=
-createdOn=
+description=Xbox 360 XEX loader for Ghidra with XEX, XEXP, PDB, and XDB support.
+author=Warranty Voider; SaveEditors fork maintenance
+createdOn=2026-03-23
 version=@extversion@

--- a/XEXLoaderWV/ghidra_scripts/AuditPdbArrayImport.java
+++ b/XEXLoaderWV/ghidra_scripts/AuditPdbArrayImport.java
@@ -1,0 +1,101 @@
+// Audits LF_ARRAY import outcomes so skipped arrays can be classified by reason.
+
+import ghidra.app.script.GhidraScript;
+import ghidra.program.model.data.DataType;
+import xexloaderwv.PDBFile;
+import xexloaderwv.TPIStream;
+import xexloaderwv.TypeRecord;
+import xexloaderwv.TypeRecord.LeafRecordKind;
+
+public class AuditPdbArrayImport extends GhidraScript {
+
+	@Override
+	protected void run() throws Exception {
+		String[] args = getScriptArgs();
+		if (args.length < 1) {
+			throw new IllegalArgumentException("Usage: AuditPdbArrayImport.java <path-to-pdb>");
+		}
+
+		String pdbPath = args[0];
+		printf("Loading PDB for array audit: %s%n", pdbPath);
+
+		PDBFile pdb = new PDBFile(pdbPath, monitor, currentProgram);
+		pdb.tpi.ImportTypeRecords(currentProgram, monitor);
+
+		int imported = 0;
+		int skippedZeroLength = 0;
+		int skippedMissingElementType = 0;
+		int skippedInvalidElementLength = 0;
+		int skippedNonDivisible = 0;
+		int skippedUnexpected = 0;
+		StringBuilder details = new StringBuilder();
+
+		for (TypeRecord rec : pdb.tpi.typeRecords) {
+			if (rec.kind != LeafRecordKind.LF_ARRAY || !(rec.record instanceof TypeRecord.LR_Array)) {
+				continue;
+			}
+
+			TypeRecord.LR_Array arr = (TypeRecord.LR_Array) rec.record;
+			if (arr.dataType != null) {
+				imported++;
+				continue;
+			}
+
+			long expectedLength = arr.val.val_long;
+			DataType elementType = null;
+			try {
+				elementType = pdb.tpi.GetDataTypeByIndex(arr.elemtype);
+			}
+			catch (Exception ex) {
+				elementType = null;
+			}
+
+			String reason;
+			if (expectedLength == 0) {
+				skippedZeroLength++;
+				reason = "zero-length";
+			}
+			else if (elementType == null) {
+				skippedMissingElementType++;
+				reason = "missing-element-type";
+			}
+			else if (elementType.getLength() <= 0) {
+				skippedInvalidElementLength++;
+				reason = "invalid-element-length";
+			}
+			else if ((expectedLength % elementType.getLength()) != 0) {
+				skippedNonDivisible++;
+				reason = "non-divisible";
+			}
+			else {
+				skippedUnexpected++;
+				reason = "unexpected";
+			}
+
+			if (details.length() < 6000) {
+				String typeName = pdb.tpi.GetDataTypeNameByIndex(arr.elemtype);
+				String elementName = typeName == null ? "<null>" : typeName;
+				String elementLength = elementType == null ? "<null>" : Integer.toString(elementType.getLength());
+				details.append(String.format(
+					"typeID=0x%X name=%s expectedBytes=%d elemType=0x%X elemName=%s elemLen=%s reason=%s%n",
+					rec.typeID, arr.name, expectedLength, arr.elemtype, elementName, elementLength, reason));
+			}
+		}
+
+		printf(
+			"Array audit summary: imported=%d skippedZeroLength=%d skippedMissingElementType=%d skippedInvalidElementLength=%d skippedNonDivisible=%d skippedUnexpected=%d%n",
+			imported,
+			skippedZeroLength,
+			skippedMissingElementType,
+			skippedInvalidElementLength,
+			skippedNonDivisible,
+			skippedUnexpected);
+		if (details.length() > 0) {
+			printf("%s", details.toString());
+		}
+
+		if (skippedUnexpected > 0) {
+			throw new RuntimeException("Unexpected skipped arrays were found.");
+		}
+	}
+}

--- a/XEXLoaderWV/ghidra_scripts/ValidatePdbArrayLengths.java
+++ b/XEXLoaderWV/ghidra_scripts/ValidatePdbArrayLengths.java
@@ -1,0 +1,60 @@
+// Validates that imported LF_ARRAY datatypes use the byte length encoded in the PDB.
+
+import ghidra.app.script.GhidraScript;
+import xexloaderwv.PDBFile;
+import xexloaderwv.TypeRecord;
+import xexloaderwv.TypeRecord.LeafRecordKind;
+
+public class ValidatePdbArrayLengths extends GhidraScript {
+
+	@Override
+	protected void run() throws Exception {
+		String[] args = getScriptArgs();
+		if (args.length < 1) {
+			throw new IllegalArgumentException("Usage: ValidatePdbArrayLengths.java <path-to-pdb>");
+		}
+
+		String pdbPath = args[0];
+		printf("Loading PDB for array validation: %s%n", pdbPath);
+
+		PDBFile pdb = new PDBFile(pdbPath, monitor, currentProgram);
+		pdb.tpi.ImportTypeRecords(currentProgram, monitor);
+
+		int checked = 0;
+		int skipped = 0;
+		int mismatches = 0;
+		StringBuilder details = new StringBuilder();
+
+		for (TypeRecord rec : pdb.tpi.typeRecords) {
+			if (rec.kind != LeafRecordKind.LF_ARRAY || !(rec.record instanceof TypeRecord.LR_Array)) {
+				continue;
+			}
+
+			TypeRecord.LR_Array arr = (TypeRecord.LR_Array) rec.record;
+			if (arr.dataType == null) {
+				skipped++;
+				continue;
+			}
+
+			long expectedLength = arr.val.val_long;
+			int actualLength = arr.dataType.getLength();
+			checked++;
+
+			if (actualLength != expectedLength) {
+				mismatches++;
+				if (details.length() < 4000) {
+					details.append(String.format(
+						"typeID=0x%X name=%s expectedBytes=%d actualBytes=%d elemType=0x%X%n",
+						rec.typeID, arr.name, expectedLength, actualLength, arr.elemtype));
+				}
+			}
+		}
+
+		printf("Array validation summary: checked=%d skipped=%d mismatches=%d%n",
+			checked, skipped, mismatches);
+
+		if (mismatches > 0) {
+			throw new RuntimeException("Found array length mismatches:\n" + details);
+		}
+	}
+}

--- a/XEXLoaderWV/src/main/java/xexloaderwv/CodeViewTypeInfo.java
+++ b/XEXLoaderWV/src/main/java/xexloaderwv/CodeViewTypeInfo.java
@@ -1,0 +1,51 @@
+package xexloaderwv;
+
+final class CodeViewTypeInfo {
+
+	private CodeViewTypeInfo() {
+	}
+
+	static int getPrimitiveStorageSize(long typeIndex) {
+		switch ((int) typeIndex) {
+			case 0x0010: // T_CHAR
+			case 0x0020: // T_UCHAR
+			case 0x0068: // T_INT1
+			case 0x0069: // T_UINT1
+			case 0x0070: // T_RCHAR
+			case 0x0030: // T_BOOL08
+				return 1;
+			case 0x0011: // T_SHORT
+			case 0x0021: // T_USHORT
+			case 0x0071: // T_WCHAR
+			case 0x0072: // T_INT2
+			case 0x0073: // T_UINT2
+			case 0x0031: // T_BOOL16
+			case 0x007a: // T_CHAR16
+				return 2;
+			case 0x0008: // T_HRESULT
+			case 0x0012: // T_LONG
+			case 0x0022: // T_ULONG
+			case 0x0040: // T_REAL32
+			case 0x0074: // T_INT4
+			case 0x0075: // T_UINT4
+			case 0x0032: // T_BOOL32
+			case 0x007b: // T_CHAR32
+				return 4;
+			case 0x0013: // T_QUAD
+			case 0x0023: // T_UQUAD
+			case 0x0041: // T_REAL64
+			case 0x0076: // T_INT8
+			case 0x0077: // T_UINT8
+			case 0x0033: // T_BOOL64
+				return 8;
+			case 0x0014: // T_OCT
+			case 0x0024: // T_UOCT
+			case 0x0043: // T_REAL128
+			case 0x0078: // T_INT16
+			case 0x0079: // T_UINT16
+				return 16;
+			default:
+				return -1;
+		}
+	}
+}

--- a/XEXLoaderWV/src/main/java/xexloaderwv/PDBFile.java
+++ b/XEXLoaderWV/src/main/java/xexloaderwv/PDBFile.java
@@ -60,9 +60,7 @@ public class PDBFile {
 		int pos;
 		pos = pAdIndexPages * dPageBytes;
 		ArrayList<Integer> pages = new ArrayList<Integer>();
-		int count = dRootBytes / dPageBytes;
-        if ((dRootBytes / dPageBytes) != 0)
-            count++;
+		int count = GetPageCount(dRootBytes);
 		for(int i = 0; i < count; i++)
 		{
 			int v = b.readInt(pos);
@@ -150,9 +148,7 @@ public class PDBFile {
 			try
 			{
 				RootStream rs = rootStreams.get(i);
-				int subcount = rs.size / dPageBytes;
-	            if ((rs.size % dPageBytes) != 0)
-	                subcount++;
+				int subcount = GetPageCount(rs.size);
 	            rs.pages = new int[subcount];
 	            for(int j = 0; j < subcount; j++)
 	            {
@@ -163,5 +159,15 @@ public class PDBFile {
 			}
 			catch(Exception e) {}
 		}
+	}
+
+	private int GetPageCount(int byteCount)
+	{
+		if(byteCount <= 0)
+			return 0;
+		int count = byteCount / dPageBytes;
+		if((byteCount % dPageBytes) != 0)
+			count++;
+		return count;
 	}
 }

--- a/XEXLoaderWV/src/main/java/xexloaderwv/TPIStream.java
+++ b/XEXLoaderWV/src/main/java/xexloaderwv/TPIStream.java
@@ -486,7 +486,7 @@ public class TPIStream {
 			if(rec.typeID == en.field)
 			{
 				TypeRecord.LR_FieldList fieldList = (TypeRecord.LR_FieldList)rec.record;
-				EnumDataType newEnum = new EnumDataType(en.name, 8);
+				EnumDataType newEnum = new EnumDataType(en.name, ResolveEnumStorageSize(en));
 				for(TypeRecord.MemberRecord m : fieldList.records)
 				{
 					TypeRecord.MR_Enumerate entry = (TypeRecord.MR_Enumerate)m;
@@ -496,6 +496,24 @@ public class TPIStream {
 				return true;
 			}
 		return false;
+	}
+
+	private int ResolveEnumStorageSize(TypeRecord.LR_Enum en)
+	{
+		int primitiveSize = CodeViewTypeInfo.getPrimitiveStorageSize(en.utype);
+		if(primitiveSize > 0)
+			return primitiveSize;
+
+		try
+		{
+			DataType dataType = GetDataTypeByIndex(en.utype);
+			if(dataType != null && dataType.getLength() > 0)
+				return dataType.getLength();
+		}
+		catch (Exception ex)
+		{
+		}
+		return 8;
 	}
 	
 	public LeafRecordKind GetTypeKind(long index)

--- a/XEXLoaderWV/src/main/java/xexloaderwv/TPIStream.java
+++ b/XEXLoaderWV/src/main/java/xexloaderwv/TPIStream.java
@@ -144,15 +144,23 @@ public class TPIStream {
 			isBitField = isB;
 		}
 	}
+
+	private static class ImportSummary
+	{
+		long countEnums;
+		long countStructures;
+		long countArrays;
+		long countUnions;
+		long countClasses;
+		long countModifiers;
+		long skippedZeroLengthArrays;
+		long skippedMissingElementTypeArrays;
+		long skippedInvalidElementLengthArrays;
+		long skippedNonDivisibleArrays;
+	}
 	
 	public void ImportTypeRecords(Program program, TaskMonitor monitor) throws Exception
 	{
-		long countEnums = 0;
-		long countStructures = 0;
-		long countArrays = 0;
-		long countUnions = 0;
-		long countClasses = 0;
-		long countModifiers = 0;
 		DataTypeManager dtMan = program.getDataTypeManager();
 		monitor.setMaximum(typeRecords.size());
 		monitor.setMessage("Loading type records");
@@ -168,33 +176,28 @@ public class TPIStream {
 			switch(rec.kind)
 			{
 				case LF_ENUM:
-					if(AddEnumType((TypeRecord.LR_Enum)rec.record))
-						countEnums++;					
+					AddEnumType((TypeRecord.LR_Enum)rec.record);
 					break;
 				case LF_STRUCTURE:
-					if(AddStructureType((TypeRecord.LR_Structure)rec.record))
-						countStructures++;					
+					AddStructureType((TypeRecord.LR_Structure)rec.record);
 					break;
 				case LF_ARRAY:
-					if(AddArrayType((TypeRecord.LR_Array)rec.record))
-						countArrays++;
+					AddArrayType((TypeRecord.LR_Array)rec.record);
 					break;
 				case LF_UNION:
-					if(AddUnionType((TypeRecord.LR_Union)rec.record))
-						countUnions++;
+					AddUnionType((TypeRecord.LR_Union)rec.record);
 					break;
 				case LF_CLASS:
-					if(AddClassType((TypeRecord.LR_Class)rec.record))
-						countClasses++;	
+					AddClassType((TypeRecord.LR_Class)rec.record);
 					break;
 				case LF_MODIFIER:
-					if (AddModifierType((TypeRecord.LR_Modifier)rec.record))
-						countModifiers++;
+					AddModifierType((TypeRecord.LR_Modifier)rec.record);
 					break;
 				default:
 					break;
 			}
-		}		
+		}
+		RefineCompositeTypeSizes();
 		for(TypeRecord rec : typeRecords)
 			try
 			{
@@ -203,13 +206,131 @@ public class TPIStream {
 			} catch (Exception ex) {				
 				Log.error("Failed to add " + rec.record.dataType.getName() + ":" + ex.getMessage());
 			}
-	    Log.info(String.format("XEX Loader: Imported %d enums, %d structures, %d arrays, %d unions, %d classes, %d modifiers", 
-	    						countEnums, 
-	    						countStructures, 
-	    						countArrays, 
-	    						countUnions,
-	    						countClasses,
-								countModifiers));
+		ImportSummary summary = BuildImportSummary();
+		Log.info(String.format("XEX Loader: Imported %d enums, %d structures, %d arrays, %d unions, %d classes, %d modifiers",
+								summary.countEnums,
+								summary.countStructures,
+								summary.countArrays,
+								summary.countUnions,
+								summary.countClasses,
+								summary.countModifiers));
+		long skippedArrays = summary.skippedZeroLengthArrays +
+				summary.skippedMissingElementTypeArrays +
+				summary.skippedInvalidElementLengthArrays +
+				summary.skippedNonDivisibleArrays;
+		if(skippedArrays > 0)
+			Log.info(String.format("XEX Loader: Skipped %d arrays (%d zero-length, %d missing element types, %d invalid element sizes, %d non-divisible byte lengths)",
+					skippedArrays,
+					summary.skippedZeroLengthArrays,
+					summary.skippedMissingElementTypeArrays,
+					summary.skippedInvalidElementLengthArrays,
+					summary.skippedNonDivisibleArrays));
+	}
+
+	private void RefineCompositeTypeSizes()
+	{
+		// Array sizes depend on the finalized size of their element types. Rebuild arrays and then
+		// rebuild composites a few times so nested structs/unions/classes settle on the correct sizes.
+		for(int pass = 0; pass < 3; pass++)
+		{
+			for(TypeRecord rec : typeRecords)
+				if(rec.kind == LeafRecordKind.LF_ARRAY)
+					AddArrayType((TypeRecord.LR_Array)rec.record);
+
+			for(TypeRecord rec : typeRecords)
+				switch(rec.kind)
+				{
+					case LF_STRUCTURE:
+						AddStructureType((TypeRecord.LR_Structure)rec.record);
+						break;
+					case LF_UNION:
+						AddUnionType((TypeRecord.LR_Union)rec.record);
+						break;
+					case LF_CLASS:
+						AddClassType((TypeRecord.LR_Class)rec.record);
+						break;
+					default:
+						break;
+				}
+		}
+	}
+
+	private ImportSummary BuildImportSummary()
+	{
+		ImportSummary summary = new ImportSummary();
+		for(TypeRecord rec : typeRecords)
+		{
+			if(rec.record == null)
+				continue;
+			switch(rec.kind)
+			{
+				case LF_ENUM:
+					if(((TypeRecord.LR_Enum)rec.record).dataType != null)
+						summary.countEnums++;
+					break;
+				case LF_STRUCTURE:
+					if(((TypeRecord.LR_Structure)rec.record).dataType != null)
+						summary.countStructures++;
+					break;
+				case LF_ARRAY:
+					TypeRecord.LR_Array arr = (TypeRecord.LR_Array)rec.record;
+					if(arr.dataType != null)
+						summary.countArrays++;
+					else
+						ClassifySkippedArray(arr, summary);
+					break;
+				case LF_UNION:
+					if(((TypeRecord.LR_Union)rec.record).dataType != null)
+						summary.countUnions++;
+					break;
+				case LF_CLASS:
+					if(((TypeRecord.LR_Class)rec.record).dataType != null)
+						summary.countClasses++;
+					break;
+				case LF_MODIFIER:
+					if(((TypeRecord.LR_Modifier)rec.record).dataType != null)
+						summary.countModifiers++;
+					break;
+				default:
+					break;
+			}
+		}
+		return summary;
+	}
+
+	private void ClassifySkippedArray(TypeRecord.LR_Array arr, ImportSummary summary)
+	{
+		if(arr.val.val_long == 0)
+		{
+			summary.skippedZeroLengthArrays++;
+			return;
+		}
+		try
+		{
+			DataType dt = GetDataTypeByIndex(arr.elemtype);
+			if(dt == null)
+			{
+				summary.skippedMissingElementTypeArrays++;
+				return;
+			}
+			int elementLength = dt.getLength();
+			if(elementLength <= 0)
+			{
+				summary.skippedInvalidElementLengthArrays++;
+				return;
+			}
+			if((arr.val.val_long % elementLength) != 0)
+			{
+				summary.skippedNonDivisibleArrays++;
+				return;
+			}
+		}
+		catch (Exception ex)
+		{
+			summary.skippedMissingElementTypeArrays++;
+			return;
+		}
+		summary.skippedMissingElementTypeArrays++;
 	}
 	
 	private boolean AddClassType(TypeRecord.LR_Class clazz)
@@ -464,12 +585,20 @@ public class TPIStream {
 	{
 		try
 		{
+			arr.dataType = null;
 			DataType dt = GetDataTypeByIndex(arr.elemtype);
 			if(dt != null)
 			{
-				BinaryReader b = new BinaryReader(new ByteArrayProvider(arr.val.data), true);
-				int len = b.readUnsignedShort(0);
-				arr.dataType = new ArrayDataType(dt, len, 0);
+				int elementLength = dt.getLength();
+				if(elementLength <= 0)
+					return false;
+				long byteLength = arr.val.val_long;
+				if(byteLength <= 0 || (byteLength % elementLength) != 0)
+					return false;
+				long elementCount = byteLength / elementLength;
+				if(elementCount > Integer.MAX_VALUE)
+					return false;
+				arr.dataType = new ArrayDataType(dt, (int)elementCount, 0);
 				return true;
 			}
 			return false;

--- a/XEXLoaderWV/src/main/java/xexloaderwv/XEXHeader.java
+++ b/XEXLoaderWV/src/main/java/xexloaderwv/XEXHeader.java
@@ -9,6 +9,8 @@ import java.util.List;
 import org.apache.commons.lang3.exception.ExceptionUtils;
 import org.python.jline.internal.Log;
 
+import ghidra.app.cmd.disassemble.DisassembleCommand;
+import ghidra.app.cmd.function.CreateFunctionCmd;
 import ghidra.app.util.MemoryBlockUtils;
 import ghidra.app.util.Option;
 import ghidra.app.util.bin.BinaryReader;
@@ -397,14 +399,19 @@ public class XEXHeader {
 	public void ProcessPData(byte[] data, Program program, TaskMonitor monitor) throws Exception	
 	{
 		BinaryReader b = new BinaryReader(new ByteArrayProvider(data), false);
+		int created = 0;
 		for(int i = 0; i < data.length; i += 8)
 		{
 			int address = b.readInt(i);
 			Address addr = MakeAddress(address & 0xFFFFFFFFL);
 			if(addr != null)
+			{
 				SymbolUtilities.createPreferredLabelOrFunctionSymbol(program, addr, null, "Function_" + String.format("%08X", address), SourceType.ANALYSIS);
+				if(EnsureFunction(addr, program, monitor))
+					created++;
+			}
 		}
-		Log.info("XEX Loader: Loaded " + (data.length / 8) + " additional function symbols");
+		Log.info("XEX Loader: Loaded " + (data.length / 8) + " additional function symbols and defined " + created + " functions");
 	}
 	
 	public void ProcessPEImage(Program program, TaskMonitor monitor, MessageLog log, boolean ProcessPData) throws Exception
@@ -471,5 +478,33 @@ public class XEXHeader {
 	        }
 	    }
 	    return null;
+	}
+
+	private boolean EnsureFunction(Address addr, Program program, TaskMonitor monitor)
+	{
+		try
+		{
+			if(program.getFunctionManager().getFunctionAt(addr) != null)
+				return false;
+
+			if(program.getListing().getInstructionAt(addr) == null)
+			{
+				DisassembleCommand disassembleCmd = new DisassembleCommand(addr, null, true);
+				disassembleCmd.enableCodeAnalysis(false);
+				disassembleCmd.applyTo(program, monitor);
+			}
+
+			if(program.getListing().getInstructionAt(addr) == null)
+				return false;
+
+			CreateFunctionCmd createFunctionCmd = new CreateFunctionCmd(addr, false);
+			if(!createFunctionCmd.applyTo(program, monitor))
+				return false;
+			return program.getFunctionManager().getFunctionAt(addr) != null;
+		}
+		catch (Exception ex)
+		{
+			return false;
+		}
 	}
 }


### PR DESCRIPTION
## Summary
- fix imported PDB enums so they use the size of their underlying type instead of always using 8 bytes
- fix root stream page counting so PDBs with sub-page root directories parse correctly
- fix CodeView `LF_ARRAY` imports so the stored byte length is converted to an element count using the resolved element type size
- turn `.pdata` entries into real Ghidra functions instead of leaving label-only `Function_<addr>` symbols
- add headless validation scripts for PDB array-length regression checks and skipped-array auditing

## What Was Broken
`TPIStream.AddEnumType` always created `EnumDataType` with a size of `8`, even when the CodeView `LF_ENUM` record specified a smaller underlying type.

`PDBFile` also rounded root stream page counts incorrectly. When the PDB root directory or a root stream was smaller than one page, the loader could compute `0` pages and fail to read the stream layout correctly.

`TPIStream.AddArrayType` treated the CodeView `LF_ARRAY` length value as an element count. On real samples that produced oversized arrays whenever the PDB stored total byte length, which is the CodeView behavior.

`.pdata` processing only created labels. Ghidra would show `Function_<addr>` symbols without actually creating functions at those entry points.

## What Changed
`TPIStream` now resolves enum storage size from the enum's CodeView underlying type. Primitive backing types map directly to the correct byte width, and non-primitive cases fall back to the resolved Ghidra datatype length.

`PDBFile` now uses correct page-count rounding for the root directory and root streams, so small modern PDBs are parsed instead of being dropped.

`TPIStream` now rebuilds arrays using the final resolved element size, converts byte length to element count, clears stale array datatypes before rebuild, and logs skipped-array reasons in aggregate so unresolved cases are no longer silent.

`XEXHeader.ProcessPData` now attempts disassembly and explicit function creation for each `.pdata` entry instead of only assigning a label.

## Validation
- reproduced the original enum bug with a regression harness: a byte-backed enum imported as 8 bytes before the fix
- verified the patched loader imports byte/word/dword/qword enums as 1/2/4/8 bytes
- verified a synthetic native PDB parses and imports end to end in headless Ghidra
- `Mesh.xex` + `Mesh.pdb`: `ValidatePdbArrayLengths.java` reported `checked=782 skipped=175 mismatches=0`
- `Aurora.xex`: headless import succeeded and `.pdata` defined `35421` functions
- `Mesh.xex`: headless import succeeded and `.pdata` defined `3649` functions
- `JRPC2.xex`: `XeCLI rgh ghidra install-loader --archive <zip>` installed this build cleanly into Ghidra 12.0.4, and `rgh ghidra analyze` then imported/analyzed successfully with `.pdata` defining `459` functions
- `XDRPC.xex`: headless import succeeded and `.pdata` defined `488` functions
- `xbdm.xex`: headless import succeeded and `.pdata` loaded `259` entries while defining `252` new functions
- `AuditPdbArrayImport.java` on `Mesh.pdb` classified the remaining skipped arrays as `38` zero-length, `119` missing element type, and `18` non-divisible byte lengths; those are broader pre-existing type-resolution gaps, not regressions from this PR

Addresses #26, #30, and #31.

Validations were completed with the help of [XeCLI](https://github.com/SaveEditors/xecli).