### PR TITLE
ci: Initial workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,35 @@
+name: Build extension
+
+on: [push, pull_request, workflow_dispatch]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        ghidra:
+          - "12.1.2"
+          - "latest"
+    
+    steps:
+      - uses: actions/checkout@v7
+      - uses: actions/setup-java@v5
+        with:
+          java-version: 21
+          distribution: temurin
+      - uses: gradle/actions/setup-gradle@v6
+      - uses: antoniovazquezblanco/setup-ghidra@v2
+        with:
+          auth_token: ${{ secrets.GITHUB_TOKEN }}
+          version: ${{ matrix.ghidra }}
+      - name: Build with gradle
+        working-directory: XEXLoaderWV
+        run: gradle -PGHIDRA_INSTALL_DIR=${{ env.GHIDRA_INSTALL_DIR }}
+      - name: Upload artifact
+        uses: actions/upload-artifact@v7
+        with:
+          name: extension_for_ghidra_${{ matrix.ghidra }}
+          path: XEXLoaderWV/dist/*.zip
+          if-no-files-found: error
+          retention-days: 30

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -21,7 +21,6 @@ jobs:
       - uses: gradle/actions/setup-gradle@v6
       - uses: antoniovazquezblanco/setup-ghidra@v2
         with:
-          auth_token: ${{ secrets.GITHUB_TOKEN }}
           version: ${{ matrix.ghidra }}
       - name: Build with gradle
         working-directory: XEXLoaderWV


### PR DESCRIPTION
This adds a basic CI workflow to build the extension via github actions.
It does not implement auto-release on git-tag, so you can still validate the built artifact before actually drafting a release.

Hope this eases the pain of constantly updating the extension ;)